### PR TITLE
Fix folder selection inside subfolder (Drag n drop)

### DIFF
--- a/src/utils/get-tabulations.js
+++ b/src/utils/get-tabulations.js
@@ -1,6 +1,6 @@
 const getTabulations = (rowKey, location) => {
   const locationWithRoot = location.pathname.split('/').filter((folder) => folder !== '');
-  const locationWithoutRoot = locationWithRoot.slice(2, locationWithRoot.length);
+  const locationWithoutRoot = locationWithRoot.slice(1, locationWithRoot.length);
   const rootFolderAmount = locationWithoutRoot.length;
   const currentItemFolderAmount = rowKey.split('/').length;
   const tabulations = currentItemFolderAmount - rootFolderAmount - 1;


### PR DESCRIPTION
## Changelog

- Fix folder selection inside subfolder (Drag n drop)

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [x] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- [CH21225](https://app.clubhouse.io/terminalsystems/story/21225/drag-n-drop-inside-a-subfolder-on-drag-over-is-always-selecting-first-folder-as-target)

### Screenshots/Gifs:

![2021-01-25 06 37 46](https://user-images.githubusercontent.com/20387722/105688400-519b2100-5ed8-11eb-85b8-60dc9ae83ef8.gif)

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
