### PR TITLE
Added onbeforeunload event while user is uploading files

### DIFF
--- a/src/events/add-items-subscribe.js
+++ b/src/events/add-items-subscribe.js
@@ -34,6 +34,8 @@ export const addItems = ({
   const storage = await sdk.getStorage();
   const modalId = dispatch(openModal(UPLOAD_PROGRESS_TOAST));
 
+  window.onbeforeunload = () => false;
+
   dispatch({
     type: INIT_UPLOAD_STATE,
     payload: {
@@ -56,6 +58,8 @@ export const addItems = ({
   uploadResponse.on('error', (data) => {
     // eslint-disable-next-line no-console
     console.error('SUBSCRIBE_ERROR_EVENT', data);
+
+    window.onbeforeunload = null;
 
     dispatch({
       type: SET_UPLOAD_ERROR_STATE,
@@ -213,6 +217,10 @@ export const addItems = ({
         });
       }
     }
+  });
+
+  uploadResponse.once('done', () => {
+    window.onbeforeunload = null;
   });
 };
 


### PR DESCRIPTION
## Changelog

- Added `onbeforeunload` event while user is uploading files

### Type of changes included:

- [ ] Components
- [x] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- [CH21205](https://app.clubhouse.io/terminalsystems/story/21205/display-a-warning-message-if-user-tries-to-close-the-browser-while-is-uploading-files)

### Screenshots/Gifs:

![2021-01-26 13 21 27](https://user-images.githubusercontent.com/20387722/105875746-eedf7d80-5fdc-11eb-8232-e04af6ddf22e.gif)


### Notes:

default message can't be changed according: https://javascript.info/onload-ondomcontentloaded#window.onbeforeunload

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
