### PR TITLE
Added preload files on loading view

### DIFF
--- a/src/events/objects.js
+++ b/src/events/objects.js
@@ -100,11 +100,11 @@ export const fetchSharedObjects = (seek = '', limit = 100) => {
   }, 1000);
 };
 
-export const fetchDir = async (path = '', bucket = 'personal', fetchSubFolders = true) => {
+export const fetchDir = async (path = '', bucket = 'personal', fetchSubFolders = true, loading = true) => {
   store.dispatch({
     payload: {
       bucket,
-      loading: true,
+      loading,
     },
     type: SET_LOADING_STATE_BUCKET,
   });

--- a/src/shared/components/PrivateRoute/index.js
+++ b/src/shared/components/PrivateRoute/index.js
@@ -7,6 +7,7 @@ import Box from '@material-ui/core/Box';
 
 import { sdk } from '@clients';
 import registerTxlSubscribeEvents from '@events/txl-subscribe';
+import { listDirectory } from '@events/objects';
 
 import Splash from '../../../views/Splash';
 
@@ -27,11 +28,16 @@ const PrivateRoute = ({ children, txlSubscribe, ...rest }) => {
       }
     };
 
+    const preloadData = async (cb) => {
+      await listDirectory('', 'personal', false);
+      cb();
+    };
+
     if (sdk.isStarting) {
       sdkUnsubscribe = sdk.onList('ready', (error) => {
         if (!error) {
-          setLoadingSdk(false);
           sdkUnsubscribe();
+          preloadData(() => setLoadingSdk(false));
 
           if (txlSubscribe) {
             initTxlSubscribe();
@@ -40,7 +46,7 @@ const PrivateRoute = ({ children, txlSubscribe, ...rest }) => {
       });
     } else {
       // SDK is already started
-      setLoadingSdk(false);
+      preloadData(() => setLoadingSdk(false));
       if (txlSubscribe) {
         initTxlSubscribe();
       }

--- a/src/views/Storage/Files/index.js
+++ b/src/views/Storage/Files/index.js
@@ -20,7 +20,8 @@ const StorageMainView = () => {
   const prefix = get(match, 'params.0', '') || '';
 
   useEffect(() => {
-    fetchDir(prefix);
+    const showLoading = prefix !== '';
+    fetchDir(prefix, 'personal', true, showLoading);
   }, [history.location.pathname]);
 
   const breadcrumbsItems = mapBreadcrumbs(t('navigation.files'), location.pathname, history);


### PR DESCRIPTION
## Changelog

- Added preload files on loading view

### Type of changes included:

- [ ] Components
- [x] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- [CH21203](https://app.clubhouse.io/terminalsystems/story/21203/prevent-filetable-skeleton-after-loading-screen)

### Screenshots/Gifs:

![2021-01-26 18 17 25](https://user-images.githubusercontent.com/20387722/105907511-cd45bc80-6003-11eb-9065-7fb2a1bb30c3.gif)


### Notes:

@morochroyce This PR add the code to preload the user files located at root directory, however, listDirectory for 10 files is taking aprox 30 seconds, which means that the users are going to stay in the loading screen for several seconds. Maybe is not a good idea keep the initialization of the SDK and the preload of files in the same loading screen since users can think that the app is stuck. maybe it's better to leave it as is rn, with the skeleton for listing the directories. let me know what do you thing

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
