### PR TITLE
Resend magic link from email link

### DIFF
--- a/src/clients/api/endpoints/identity.js
+++ b/src/clients/api/endpoints/identity.js
@@ -14,6 +14,7 @@ const DEFAULT_PATH = '/identity';
 /**
  * @typedef {Object} UpdatePayload
  * @property {string} token - Auth token.
+ * @property {string} email - Identity email.
  * @property {string=} username - Identity username.
  * @property {string=} displayName - Identity displayname.
  *
@@ -23,6 +24,7 @@ const DEFAULT_PATH = '/identity';
  */
 function update(payload) {
   const { token, ...data } = payload;
+
   return this.instance({
     data,
     method: 'put',

--- a/src/events/auth.js
+++ b/src/events/auth.js
@@ -102,6 +102,7 @@ export const signup = (payload) => async (dispatch) => {
 
     const { data } = await apiClient.identity.update({
       token: spaceUser.token,
+      email: payload.torusRes.userInfo.email,
       displayName: payload.torusRes.userInfo.name,
     });
 

--- a/src/views/Auth/EmailLinkAuth/EmailLinkAuth.js
+++ b/src/views/Auth/EmailLinkAuth/EmailLinkAuth.js
@@ -13,6 +13,7 @@ const EmailLinkAuth = () => {
   const classes = useStyles();
   const location = useLocation();
   const { t } = useTranslation();
+  const [email, setEmail] = React.useState('');
   const { sendPasswordlessEmail } = useAuth0Passwordless();
 
   const from = (location.state && location.state.from) || 'signin';
@@ -24,6 +25,33 @@ const EmailLinkAuth = () => {
       email: location.state && location.state.email ? location.state.email : '',
     });
   };
+
+  React.useEffect(() => {
+    const urlParams = new URLSearchParams(location.search);
+    const resendEmail = urlParams.get('resend');
+
+    if (location.state && location.state.email) {
+      setEmail(location.state.email);
+      return;
+    }
+
+    if (resendEmail) {
+      setEmail(resendEmail);
+      const resendMagicLink = async () => {
+        try {
+          await sendPasswordlessEmail({
+            from,
+            email: resendEmail,
+          });
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error(`Error when trying to resend the magic link email: ${error.message}`);
+        }
+      };
+
+      resendMagicLink();
+    }
+  }, []);
 
   return (
     <div className={classes.root}>
@@ -37,7 +65,7 @@ const EmailLinkAuth = () => {
           components={[<Box fontWeight={600} component="span" />]}
           values={{
             action,
-            email: location.state && location.state.email ? location.state.email : '',
+            email,
           }}
         />
       </Typography>


### PR DESCRIPTION
## Changelog

- Support for resend magic link from the email link
- Add email field to `PUT /identity` endpoint

### Type of changes included:

- [ ] Components
- [X] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- Ticket 1
- Ticket 2
- Ticket 3

### Screenshots/Gifs:

*Place you changes screenshots here*

### Notes:

*Place special notes here*

### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
