### PR TITLE
On open file, open the preview modal instead url redirect

### DIFF
--- a/src/shared/components/ObjectsTable/ObjectsTable.js
+++ b/src/shared/components/ObjectsTable/ObjectsTable.js
@@ -176,6 +176,7 @@ const ObjectsTable = ({
 
     openAction({
       clickedItem: row,
+      dispatch,
       history,
     });
   };

--- a/src/utils/use-menu-item-on-click.js
+++ b/src/utils/use-menu-item-on-click.js
@@ -12,6 +12,7 @@ import copy from 'copy-to-clipboard';
 
 export const openAction = ({
   clickedItem,
+  dispatch,
   history,
 }) => {
   if (clickedItem.isUploading && clickedItem.error) {
@@ -22,7 +23,7 @@ export const openAction = ({
     history.push(redirectUrl);
   } else if (clickedItem.type === 'file') {
     if (clickedItem.uuid && clickedItem.uuid !== '') {
-      history.push(`/file/${clickedItem.uuid}`);
+      dispatch(openModal(FILE_PREVIEW, { object: clickedItem }));
     }
   }
 };
@@ -95,6 +96,7 @@ const useMenuItemOnClick = ({
         openAction({
           clickedItem,
           history,
+          dispatch,
         });
         break;
       case CONTEXT_OPTION_IDS.trash:


### PR DESCRIPTION
## Changelog

- On open file, open the preview modal instead url redirect

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [x] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- [CH21241](https://app.clubhouse.io/terminalsystems/story/21241/fix-open-file-should-trigger-modal-preview-instead-of-redirect)

### Screenshots/Gifs:

![2021-01-28 14 43 56](https://user-images.githubusercontent.com/20387722/106177596-7c56d500-6177-11eb-8801-2d471ac11301.gif)


### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
