### PR TITLE
Disabled preview button on preview

### DIFF
--- a/src/shared/components/DetailsPanel/components/Header/index.js
+++ b/src/shared/components/DetailsPanel/components/Header/index.js
@@ -31,6 +31,7 @@ const DetailsPanelHeader = ({
   showTitle,
   onClose,
   mapContextMenuItems,
+  disablePreview,
 }) => {
   const classes = useStyles({ viewMode });
   const { t } = useTranslation();
@@ -119,7 +120,7 @@ const DetailsPanelHeader = ({
               && objects[0].isAvailableInSpace
               && (
                 <>
-                  <ButtonBase>
+                  <ButtonBase disabled={disablePreview}>
                     <FontAwesomeIcon
                       onClick={() => {
                         previewAction({
@@ -128,7 +129,10 @@ const DetailsPanelHeader = ({
                         });
                       }}
                       icon={faEye}
-                      className={classes.actionIcon}
+                      className={classnames(
+                        classes.actionIcon,
+                        disablePreview && classes.disabledIcon,
+                      )}
                     />
                   </ButtonBase>
                   <ButtonBase disabled>
@@ -200,6 +204,7 @@ DetailsPanelHeader.defaultProps = {
   showTitle: true,
   onClose: () => {},
   mapContextMenuItems: (items) => items,
+  disablePreview: false,
 };
 
 DetailsPanelHeader.propTypes = {
@@ -219,6 +224,7 @@ DetailsPanelHeader.propTypes = {
   showTitle: PropTypes.bool,
   onClose: PropTypes.func,
   mapContextMenuItems: PropTypes.func,
+  disablePreview: PropTypes.bool,
 };
 
 export default DetailsPanelHeader;

--- a/src/shared/components/Modal/FilePreview/index.js
+++ b/src/shared/components/Modal/FilePreview/index.js
@@ -4,6 +4,7 @@ import Modal from '@material-ui/core/Modal';
 import TopBar from '@ui/Preview/components/TopBar';
 import FilePreviewer from '@ui/FilePreviewer';
 import { openFileByUuid } from '@events/objects';
+import { CONTEXT_OPTION_IDS } from '@ui/ContextMenu';
 import {
   getContextMenuItems,
   downloadFromUrl,
@@ -33,10 +34,10 @@ const FilePreview = ({
     clickedItem: object,
   });
 
-  const getMenuItems = () => getContextMenuItems({
-    object,
-    t,
-  });
+  const getMenuItems = () => {
+    const menuOptions = getContextMenuItems({ object, t });
+    return menuOptions.filter((item) => item.id !== CONTEXT_OPTION_IDS.preview);
+  };
 
   const getFileInfo = async () => {
     try {
@@ -112,6 +113,7 @@ const FilePreview = ({
         <PreviewDetailsPanel
           object={object}
           expanded={detailsPanelExpanded}
+          disablePreview
         />
       </div>
     </Modal>

--- a/src/views/FilePreview/components/DetailsPanel/index.js
+++ b/src/views/FilePreview/components/DetailsPanel/index.js
@@ -17,6 +17,7 @@ const PreviewDetailsPanel = ({
   expanded,
   showTitle,
   onClose,
+  disablePreview,
 }) => {
   const classes = useStyles();
   const viewMode = VIEW_MODES.PREVIEW;
@@ -41,6 +42,7 @@ const PreviewDetailsPanel = ({
           showTitle={showTitle}
           onClose={onClose}
           mapContextMenuItems={mapContextMenuItems}
+          disablePreview={disablePreview}
         />
         <Divider viewMode={viewMode} />
         {/* eslint-disable-next-line react/jsx-props-no-spreading */}
@@ -58,6 +60,7 @@ const PreviewDetailsPanel = ({
 PreviewDetailsPanel.defaultProps = {
   showTitle: false,
   onClose: () => {},
+  disablePreview: false,
 };
 
 PreviewDetailsPanel.propTypes = {
@@ -75,6 +78,7 @@ PreviewDetailsPanel.propTypes = {
   expanded: PropTypes.bool.isRequired,
   showTitle: PropTypes.bool,
   onClose: PropTypes.func,
+  disablePreview: PropTypes.bool,
 };
 
 export default PreviewDetailsPanel;

--- a/src/views/FilePreview/index.js
+++ b/src/views/FilePreview/index.js
@@ -172,6 +172,7 @@ const FilePreview = () => {
             expanded={detailsPanelExpanded}
             showTitle
             onClose={() => setDetailsPanelExpanded(false)}
+            disablePreview
           />
         </>
       )}


### PR DESCRIPTION
## Changelog

- Disabled preview button on preview

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [x] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- [CH21343](https://app.clubhouse.io/terminalsystems/story/21343/prevent-open-preview-inside-preview)

### Screenshots/Gifs:

![01](https://user-images.githubusercontent.com/20387722/106767068-430be280-6619-11eb-96ad-b7f9f42c408d.png)
![02](https://user-images.githubusercontent.com/20387722/106767083-4901c380-6619-11eb-9567-288329987050.png)
![03](https://user-images.githubusercontent.com/20387722/106767102-4bfcb400-6619-11eb-9350-4fb5f978cb3b.png)


### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
