### PR TITLE
fix high images

### DIFF
--- a/src/UI/FilePreviewer/styles.js
+++ b/src/UI/FilePreviewer/styles.js
@@ -9,7 +9,8 @@ export default makeStyles((theme) => ({
     alignItems: 'center',
   },
   image: {
-    width: '100%',
+    maxWidth: '100%',
+    maxHeight: '100%',
   },
   iframe: {
     width: '100%',


### PR DESCRIPTION
## Changelog

- Fixed images. Images that were higher than wider didn't show up properly
- Change 2
- Change 3

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [ ] Bug fixes
- [x] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- Ticket 1
- Ticket 2
- Ticket 3

### Screenshots/Gifs:

![Screenshot from 2021-02-12 12-47-27](https://user-images.githubusercontent.com/26363061/107803832-223a4000-6d31-11eb-9ff1-2a2549563cb2.png)

### Notes:

*Place special notes here*

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
