### PR TITLE
sdk not starting when no user

### DIFF
--- a/src/views/FilePreview/index.js
+++ b/src/views/FilePreview/index.js
@@ -66,9 +66,7 @@ const FilePreview = () => {
     }
   };
 
-  const initSdk = async () => {
-    let sdkUnsubscribe;
-
+  const initUser = async () => {
     // If there is no user, we generate a temporary user in order to
     // to interact with the SDK, but we don't
     if (!user) {
@@ -76,16 +74,22 @@ const FilePreview = () => {
       const identity = await users.createIdentity();
       await users.authenticate(identity);
     }
+  };
+
+  const initSdk = async () => {
+    let sdkUnsubscribe;
 
     if (sdk.isStarting) {
-      sdkUnsubscribe = sdk.onListen('ready', (error) => {
+      sdkUnsubscribe = sdk.onListen('ready', async (error) => {
         if (!error) {
+          await initUser();
           setLoadingSdk(false);
           sdkUnsubscribe();
         }
       });
     } else {
       // SDK is already started
+      initUser();
       setLoadingSdk(false);
     }
 


### PR DESCRIPTION
## Changelog

- The user was getting created before initialization of the sdk. So the code would only work if the sdk had been previously initalized, but not if it wasn't.

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [x] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- 21561
- Ticket 2
- Ticket 3

### Screenshots/Gifs:

*Place you changes screenshots here*

### Notes:

*Place special notes here*

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
