### PR TITLE
set public access fix (do not merge until sdk 0.0.27 release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@fortawesome/react-fontawesome": "^0.1.9",
     "@material-ui/core": "^4.9.14",
     "@material-ui/lab": "^4.0.0-alpha.56",
-    "@spacehq/sdk": "^0.0.26",
+    "@spacehq/sdk": "^0.0.27",
     "@terminal-packages/space-ui": "^0.3.17",
     "@toruslabs/torus-direct-web-sdk": "^3.5.7",
     "axios": "^0.20.0",

--- a/src/events/objects.js
+++ b/src/events/objects.js
@@ -318,6 +318,7 @@ export const setFileAccess = async (payload) => {
       path: payload.path,
       bucket: payload.bucket,
       allowAccess: payload.allowAccess,
+      dbId: payload.dbId,
     });
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/shared/components/Modal/Sharing/Sharing.js
+++ b/src/shared/components/Modal/Sharing/Sharing.js
@@ -93,7 +93,8 @@ const SharingModal = (props) => {
   const onShareLinkOptionClick = (option) => {
     setFileAccess({
       path: `/${selectedObjects[0].key}`,
-      bucket: selectedObjects[0].bucket,
+      bucket: selectedObjects[0].sourceBucket,
+      dbId: selectedObjects[0].dbId,
       allowAccess: option.id === 'public',
     });
     setShareLinkOptions(shareLinkOptions.map((opt) => ({


### PR DESCRIPTION
## Changelog

- Add the dbId field to setFilePublicAccess
- the bucket is the sourceBucket, not 'shared-with-me'

Merge when sdk 0.0.27 is released.

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- Ticket 1
- Ticket 2
- Ticket 3

### Screenshots/Gifs:

*Place you changes screenshots here*

### Notes:

*Place special notes here*

### Tested on:

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
