### PR TITLE
Juan.angarita/ch21610/add link to sign in auth error message

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -203,6 +203,7 @@
     },
     "signup": {
       "title": "Sign Up",
+      "signIn": "Sign in",
       "logIn": "Log in",
       "claim": "Claim Username",
       "doLater": "Do this later",
@@ -219,7 +220,7 @@
       "errors": {
         "generic": "Sorry, there was a problem.",
         "email": "Email already in use.",
-        "magicLink": "The email entered is not available. Already have an account? Sign in.",
+        "magicLink": "The email entered is not available. Already have an account?",
         "identity": "Sorry, there was a problem getting your identity.",
         "address": "Sorry, the current address is already registered.",
         "torus": "There was an error with torus integration",

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -26,6 +26,7 @@ export default (state = DEFAULT_STATE, action) => {
         ...state,
         isAuthenticating: false,
         authenticatingError: action.error,
+        link: action.link,
       };
     }
     case AUTH_ACTION_TYPES.ON_AUTHENTICATION_SUCCESS: {

--- a/src/views/Auth/components/ErrorMessage/index.js
+++ b/src/views/Auth/components/ErrorMessage/index.js
@@ -17,7 +17,7 @@ const ErrorMessage = ({ message, link }) => {
         {message}
         {
           link !== undefined && (
-            <span>
+            <Box component="span">
               <span> </span>
               <Link
                 to={`/${link.to}`}
@@ -25,7 +25,7 @@ const ErrorMessage = ({ message, link }) => {
               >
                 {link.message}
               </Link>
-            </span>
+            </Box>
           )
         }
       </Box>

--- a/src/views/Auth/components/ErrorMessage/index.js
+++ b/src/views/Auth/components/ErrorMessage/index.js
@@ -18,7 +18,7 @@ const ErrorMessage = ({ message, link }) => {
         {
           link !== undefined && (
             <Box component="span">
-              <span> </span>
+              <span>&#32;</span>
               <Link
                 to={`/${link.to}`}
                 className={classes.link}

--- a/src/views/Auth/components/ErrorMessage/index.js
+++ b/src/views/Auth/components/ErrorMessage/index.js
@@ -1,36 +1,48 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationTriangle } from '@fortawesome/pro-regular-svg-icons/faExclamationTriangle';
-
 import Box from '@material-ui/core/Box';
+import useStyles from './styles';
 
-const ErrorMessage = ({ message }) => (
-  <Box
-    pl="10px"
-    pr="14px"
-    mb="-33px"
-    bottom={0}
-    border={1}
-    height={33}
-    display="flex"
-    color="#EF6A6E"
-    borderRadius={4}
-    bgcolor="#240F10"
-    alignSelf="center"
-    position="absolute"
-    alignItems="center"
-    borderColor="#EF6A6E"
-  >
-    <FontAwesomeIcon icon={faExclamationTriangle} />
-    <Box ml="7px" component="span" color="common.white">
-      {message}
+const ErrorMessage = ({ message, link }) => {
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.root}>
+      <FontAwesomeIcon icon={faExclamationTriangle} />
+      <Box className={classes.contentBox} component="span">
+        {message}
+        {
+          link !== undefined && (
+            <span>
+              <span> </span>
+              <Link
+                to={`/${link.to}`}
+                className={classes.link}
+              >
+                {link.message}
+              </Link>
+            </span>
+          )
+        }
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};
+
+ErrorMessage.defaultProps = {
+  link: undefined,
+};
 
 ErrorMessage.propTypes = {
   message: PropTypes.string.isRequired,
+  link: PropTypes.shape({
+    to: PropTypes.string,
+    message: PropTypes.string,
+  }),
 };
 
 export default ErrorMessage;

--- a/src/views/Auth/components/ErrorMessage/index.js
+++ b/src/views/Auth/components/ErrorMessage/index.js
@@ -18,7 +18,7 @@ const ErrorMessage = ({ message, link }) => {
         {
           link !== undefined && (
             <Box component="span">
-              <span>&#32;</span>
+              &nbsp;
               <Link
                 to={`/${link.to}`}
                 className={classes.link}

--- a/src/views/Auth/components/ErrorMessage/styles.js
+++ b/src/views/Auth/components/ErrorMessage/styles.js
@@ -1,0 +1,25 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles((theme) => ({
+  root: {
+    padding: '0 14px 0 10px',
+    marginBottom: '-33px',
+    bottom: 0,
+    border: '1px solid #EF6A6E',
+    height: 33,
+    display: 'flex',
+    color: '#EF6A6E',
+    borderRadius: 4,
+    backgroundColor: '#240F10',
+    alignSelf: 'center',
+    position: 'absolute',
+    alignItems: 'center',
+  },
+  contentBox: {
+    marginLeft: 7,
+    color: theme.palette.common.white,
+  },
+  link: {
+    color: theme.palette.common.white,
+  },
+}));

--- a/src/views/Auth/index.js
+++ b/src/views/Auth/index.js
@@ -66,6 +66,10 @@ const Auth = () => {
     if (error) {
       dispatch({
         error: `modules.${match.params[0]}.errors.magicLink`,
+        link: {
+          to: 'signin',
+          message: t(`modules.${match.params[0]}.signIn`),
+        },
         type: AUTH_ACTION_TYPES.ON_AUTHENTICATION_ERROR,
       });
       return;
@@ -283,6 +287,7 @@ const Auth = () => {
               state.authenticatingError && (
                 <ErrorMessage
                   message={t(state.authenticatingError, { defaultValue: t('modules.signup.errors.generic') })}
+                  link={state.link}
                 />
               )
             }


### PR DESCRIPTION
## Changelog

- Added link to log in on auth error message
- Added support for error message to display link (if needed on any other case)
- Moved `ErrorMessage` styling to `styles.js`

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [ ] Bug fixes
- [x] Styling
- [x] Code Refactor

### Clubhouse Tickets Related:

- [Add link to sign in auth error message](https://app.clubhouse.io/terminalsystems/story/21610/add-link-to-sign-in-auth-error-message)

### Screenshots/Gifs:

https://user-images.githubusercontent.com/44899916/109761121-df47eb80-7bbd-11eb-80c3-7ae3dce4fcfc.mov

### Notes:

*Place special notes here*

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
