### PR TITLE
if there is no address do not call to get identities by address

### DIFF
--- a/src/events/identities.js
+++ b/src/events/identities.js
@@ -56,6 +56,7 @@ export const fetchRecentlyMembers = async () => {
     if (addresses.length === 0) {
       return;
     }
+
     getIdentitiesByAddress({ addresses, recentlyShared: true });
   } catch (error) {
     Sentry.captureException(error);

--- a/src/events/identities.js
+++ b/src/events/identities.js
@@ -53,6 +53,9 @@ export const fetchRecentlyMembers = async () => {
 
     const addresses = res.members.map((member) => member.address);
 
+    if (addresses.length === 0) {
+      return;
+    }
     getIdentitiesByAddress({ addresses, recentlyShared: true });
   } catch (error) {
     Sentry.captureException(error);


### PR DESCRIPTION
## Changelog

- Avoid calling get identities by address endpoint where there is no addresses

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- Ticket 1
- Ticket 2
- Ticket 3

### Screenshots/Gifs:

*Place you changes screenshots here*

### Notes:

*Place special notes here*

### Tested on:

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
